### PR TITLE
Chore: dependabotが出すprにリポジトリオーナーをレビュアーとして追加する

### DIFF
--- a/.github/workflows/add-reviewer-to-dependabot.yml
+++ b/.github/workflows/add-reviewer-to-dependabot.yml
@@ -1,0 +1,26 @@
+name: Add Reviewer to Dependabot PRs
+
+on:
+  pull_request:
+    types: [opened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  add-reviewer:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+      - name: Add Reviewer
+        run: gh pr edit $PR_NUMBER --add-reviewer $REVIEWER
+    env:
+      PR_NUMBER: ${{ github.event.number }}
+      # gh cli require GH_TOKEN variable
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      REVIEWER: ${{ github.repository_owner }}
+    


### PR DESCRIPTION
## メモ

- [gh pr editコマンド](https://cli.github.com/manual/gh_pr_edit)
- [secrets.GITHUB_TOKEN](https://zenn.dev/not75743/scraps/926f2693809744)


## Sumary

This pull request introduces a new GitHub Actions workflow to automatically add a reviewer to Dependabot-generated pull requests. The workflow is triggered when a pull request is opened by the `dependabot[bot]`.

### New GitHub Actions workflow:

* [`.github/workflows/add-reviewer-to-dependabot.yml`](diffhunk://#diff-b8d0c6d3f290b369f55401a296947780b0f9e3ee0f9ab6715e17e352a1051be7R1-R26): Created a workflow named "Add Reviewer to Dependabot PRs" that runs on `ubuntu-latest`, checks out the repository, and uses the GitHub CLI (`gh`) to add the repository owner as a reviewer to Dependabot pull requests. This is conditional on the pull request being created by `dependabot[bot]`.