### PR TITLE
chore: dependabotのprを自動でマージするワークフロー

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,31 @@
+name: Auto merge dependabot pull requests
+# Dependabotが作成したPRのうち、GitHub Actionsの更新またはパッチバージョンの更新を自動でマージする
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+    branches:
+      - main
+
+jobs:
+  automerge:
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+      - name: Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2 ## dependabotの更新内容を取得（https://github.com/dependabot/fetch-metadata）
+      - name: Auto approve and merge
+        if: ${{ steps.meta.outputs.package-ecosystem == 'github_actions' || steps.meta.outputs.update-type != 'version-update:semver-major' }}
+        run: |
+          # リポジトリ設定のAllow GitHub Actions to create and approve pull requestsを有効にしておく必要あり
+          gh pr review ${{ github.event.number }} --approve
+          # autoフラグはリポジトリ設定のAllow auto-mergeを有効にしておく必要あり
+          gh pr merge ${{ github.event.number }} --merge --auto


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automatically approve and merge Dependabot pull requests for GitHub Actions updates and non-major version patches. The workflow streamlines dependency management by reducing manual intervention for safe updates.

**Automation of Dependabot PR handling:**

* Added `.github/workflows/dependabot-auto-merge.yml` to automatically approve and merge Dependabot pull requests for GitHub Actions and non-major version updates when targeting the `main` branch.
* Configured the workflow to run only for pull requests opened or marked ready for review by Dependabot, and to require appropriate repository settings for auto-merge and approvals.