### PR TITLE
Chroe: pre-commit時にmago lintを実行するように

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,13 +112,18 @@ docker compose exec app composer test
 
 ### Git フック設定 (Husky + lint-staged)
 
-JavaScript/TypeScriptファイル（`*.{js,ts,jsx,tsx,json}`）に対してBiomeリンターが自動実行されます。
+コミット時に次のファイルに対して品質チェックを自動実行します。
+
+- **JavaScript/TypeScript**（`*.{js,ts,jsx,tsx,json}`）: Biomeリンターが自動実行
+- **PHP**（`*.php`）: magoリンターが自動実行（Dockerコンテナ必要）
 
 ```bash
 docker compose exec node npm run prepare
 ```
 
 ※huskyは.gitと同階層にいないと動作しない。このプロジェクトはsrcディレクトリにpackage.jsonがあるため、`npm run prepare`コマンド実行時にsrcディレクトリを指定しています。
+
+**重要**: PHPファイルをコミットする際は、Dockerの`app`コンテナ内のmagoを使用するため、事前にコンテナを起動しておく必要があります。
 
 **設定ファイル**:
 

--- a/src/.lintstagedrc
+++ b/src/.lintstagedrc
@@ -1,3 +1,4 @@
 {
-  "*.{js,ts,jsx,tsx,json}": "npx @biomejs/biome lint --write"
+  "*.{js,ts,jsx,tsx,json}": "npx @biomejs/biome lint --write",
+  "*.php": "docker compose exec app vendor/bin/mago lint --fix"
 }


### PR DESCRIPTION
This pull request updates the lint-staged configuration to add automatic PHP linting and revises the documentation to reflect these changes. The most important changes are grouped below:

**Linting Configuration Updates:**

* Added a new lint-staged rule to automatically run the `mago` linter on PHP files (`*.php`) using the Docker `app` container in `.lintstagedrc`.

**Documentation Improvements:**

* Updated the `README.md` to clarify that, in addition to JavaScript/TypeScript files, PHP files are now automatically checked with the `mago` linter during commits.
* Added a note in the `README.md` emphasizing that the Docker `app` container must be running for PHP linting to work during commits.