### PR TITLE
Chore: GH ActoinsでPHPStanのキャッシュを使用

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -19,7 +19,7 @@ jobs:
   phpstan:
     runs-on: ubuntu-latest
     env:
-      PR_NUMBER: ${{ github.event.pull_request.number }}
+      PR_NUMBER: ${{ github.event.pull_request.number || 'manual' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -61,7 +61,7 @@ jobs:
 
       - name: "Save result cache"
         uses: actions/cache/save@v4
-        if: ${{ !cancelled() }}
+        if: ${{ github.event_name == 'pull_request' && !cancelled() }}
         with:
           path: src/vendor/phpstan/phpstan/tmp # phpstan.neonのtmpDirと合わせる
           key: "phpstan-result-cache-${{ env.PR_NUMBER }}"

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -11,6 +11,10 @@ on:
       - ".github/workflows/phpstan.yml"
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   phpstan:
     runs-on: ubuntu-latest

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -7,9 +7,7 @@ on:
       - "src/**/*.php"
       - "src/phpstan.neon"
       - "src/composer.lock"
-      - "src/composer.json"
       - "src/package-lock.json"
-      - "src/package.json"
       - ".github/workflows/phpstan.yml"
   workflow_dispatch:
 

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -14,7 +14,8 @@ on:
 jobs:
   phpstan:
     runs-on: ubuntu-latest
-
+    env:
+      PR_NUMBER: ${{ github.event.pull_request.number }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -41,6 +42,22 @@ jobs:
         run: composer install --prefer-dist --no-progress --no-suggest
         working-directory: ./src
 
+      - name: "Restore result cache"
+        uses: actions/cache/restore@v4
+        with:
+          path: src/vendor/phpstan/phpstan/tmp # phpstan.neonのtmpDirと合わせる
+          key: "phpstan-result-cache-${{ env.PR_NUMBER }}"
+          # 一致するキャッシュの内最新のものを使用する
+          restore-keys: |
+            phpstan-result-cache-
+
       - name: Run PHPStan
         run: ./vendor/bin/phpstan analyse --error-format=github
         working-directory: ./src
+
+      - name: "Save result cache"
+        uses: actions/cache/save@v4
+        if: ${{ !cancelled() }}
+        with:
+          path: src/vendor/phpstan/phpstan/tmp # phpstan.neonのtmpDirと合わせる
+          key: "phpstan-result-cache-${{ env.PR_NUMBER }}"

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -7,9 +7,7 @@ on:
       - "src/**/*.php"
       - "src/phpunit.xml"
       - "src/package-lock.json"
-      - "src/package.json"
       - "src/composer.lock"
-      - "src/composer.json"
       - ".github/workflows/phpunit.yml"
   workflow_dispatch:
 

--- a/src/phpstan.neon
+++ b/src/phpstan.neon
@@ -5,6 +5,8 @@ includes:
     - vendor/phpstan/phpstan-phpunit/rules.neon
 
 parameters:
+    tmpDir: ./vendor/phpstan/phpstan/tmp
+
     # 静的解析の厳密度レベル（0-9）
     level: 6
 


### PR DESCRIPTION
This pull request improves the PHPStan static analysis workflow by introducing caching for result files and making related configuration changes. It also makes minor adjustments to the workflow triggers for both PHPStan and PHPUnit.

**PHPStan Workflow Improvements:**

- Added caching for PHPStan result files to speed up subsequent runs by restoring and saving the result cache keyed by pull request number. (.github/workflows/phpstan.yml)
- Set the `tmpDir` parameter in `phpstan.neon` to align with the cache location used in the workflow. (src/phpstan.neon)

**Workflow Trigger Adjustments:**

- Updated the file patterns that trigger the PHPStan and PHPUnit workflows by removing `composer.json` and `package.json` from the watched files. (.github/workflows/phpstan.yml, .github/workflows/phpunit.yml) [[1]](diffhunk://#diff-73a1d6ddd0eabb7e1349cdb83b76ff10f29f9e4fe316c0cd29495174181f4546L10-R18) [[2]](diffhunk://#diff-ea12f60188cdd90bc99e5d0af2eb91647bbe4a9199176aa1ec5240f65efed510L10-L12)