### PR TITLE
Chore: GH ActionsでPHPUnitのキャッシュを利用するように

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -89,6 +89,16 @@ jobs:
         run: npm run build
         working-directory: ./src
 
+      - name: Cache PHPUnit result cache
+        uses: actions/cache@v4
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number || 'manual' }}
+        with:
+          path: ./src/.phpunit.result.cache
+          key: ${{ runner.os }}-phpunit-result-cache-${{ env.PR_NUMBER }}
+          restore-keys: |
+            ${{ runner.os }}-phpunit-result-cache-
+
       - name: Run PHPUnit
         run: composer run test
         working-directory: ./src

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -11,6 +11,10 @@ on:
       - ".github/workflows/phpunit.yml"
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for PHPUnit to improve efficiency and reliability. The main changes add concurrency control to prevent overlapping runs and introduce caching for PHPUnit result files to speed up repeated test runs.

**Workflow improvements:**

* Added a `concurrency` group to the workflow to ensure that only one run per branch or PR is active at a time, automatically canceling any in-progress runs for the same ref.

**Performance optimizations:**

* Implemented caching for the PHPUnit result cache using the `actions/cache` action, which helps to reuse test results and speeds up subsequent runs. The cache key is based on the OS and pull request number.