### PR TITLE
chore: mainへのPRでsecret-scanを実行するように変更

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,21 @@
+name: Secret scan
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+    branches:
+      - main
+
+jobs:
+  secret-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: secret lint
+        run: |
+          docker run --rm -v "$(pwd):$(pwd)" -w "$(pwd)" \
+          secretlint/secretlint secretlint --maskSecrets '**/*'


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow to automatically scan for secrets in pull requests targeting the `main` branch. This helps prevent accidental exposure of sensitive information in the codebase.

**CI/CD Improvements:**

* Added `.github/workflows/secret-scan.yml` to run a secret scanning job on pull requests to the `main` branch using `secretlint` in a Docker container.